### PR TITLE
Svelte dependency update

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "peerDependencies": {
     "@editorjs/editorjs": "^2.19.3",
-    "svelte": "3.31.0"
+    "svelte": "^3.31.0"
   },
   "files": ["dist"],
   "dependencies": {},
@@ -39,7 +39,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.42.4",
     "rollup-plugin-terser": "^7.0.2",
-    "svelte": "3.31.0",
+    "svelte": "^3.31.0",
     "typescript": "^4.2.3"
   },
   "exports": {


### PR DESCRIPTION
- Added caret `^` to svelte in `peerDependencies` and `devDependencies` so that it is not locked to that version, but to 3.3.1 and newer minor versions